### PR TITLE
Prevent invalid interval

### DIFF
--- a/views/js/pciCreator/dev/graphNumberLineInteraction/creator/widget/states/Question.js
+++ b/views/js/pciCreator/dev/graphNumberLineInteraction/creator/widget/states/Question.js
@@ -78,6 +78,22 @@ define([
             }
         });
 
+        //prevent user to enter start > end
+        var $start = $('[name="min"]','#creator-graphFunctionInteraction-axis'),
+            $end = $('[name="max"]','#creator-graphFunctionInteraction-axis');
+        $start.on('change',function(){
+            // If start >= end , set it to end - 1
+            if (parseInt($start.val()) >= parseInt($end.val())) {
+                $start.val(parseInt($end.val())-1);
+            }
+        });
+        $end.on('change',function(){
+            // If end <= start, set it to start + 1
+            if (parseInt($end.val()) <= parseInt($start.val())) {
+                $end.val(parseInt($start.val())+1);
+            }
+        });
+
         //manually get array of checked intervals
         var $intervals = $form.find('[name=intervals]');
         $intervals.on('change', function(){


### PR DESCRIPTION
The main goal of this PR is to prevent the setting of an interval with a start > end and end < start.
