### PR TITLE
Fix grid editing

### DIFF
--- a/install/local/portableSharedLibraries/PARCC/gridFactory.js
+++ b/install/local/portableSharedLibraries/PARCC/gridFactory.js
@@ -8,7 +8,7 @@ define(['OAT/lodash'], function( _){
         }
         
         if ( (options.x.start >= options.x.end) || (options.y.start >= options.y.end) ) {
-            throw 'Start must be minus than end';
+            throw 'end must be greater than start';
         }
         
         function drawLine(start, end, style){

--- a/views/js/pciCreator/dev/graphLineAndPointInteraction/pciCreator.json
+++ b/views/js/pciCreator/dev/graphLineAndPointInteraction/pciCreator.json
@@ -4,7 +4,7 @@
     "short": "Line & Point",
     "description": "Graphing Line And Point",
     "version": "0.1",
-    "author": "Thibault Milan",
+    "author": "Thibault Milan, Sam Sipasseuth",
     "email": "contact@taotesting.com",
     "libraries": [
         "IMSGlobal/jquery_2_1_1",
@@ -27,6 +27,5 @@
     "response": {
         "baseType": "integer",
         "cardinality": "single"
-    },
-    "debug" : false
+    }
 }


### PR DESCRIPTION
fix for https://breaktech.atlassian.net/browse/PARADS-2038

When a user is in Item Authoring view and tries to change the height and/or width of the graph, the actual grid disappears and user cannot see it again. This is easily reproducible when both Xmin and Xmax values are an absolute value, such as the default setting of Xmin = -10 and Xmax = 10. Although the grid disappears from the Authoring view, it still gets displayed correctly from Preview.
STEPS TO REPRODUCE:
1. Click on an Item.
2. Click on Authoring, then add a Line & Point Graphing interaction to the item.
3. Click on the Graph to enable the Interaction Properties menu in the right pane. Notice the default values are Xmin = -10, Xmax = 10, Ymin = -10, and Ymax = 10.
4. Click on the Xmin field to highlight the value ‘-10.’
5. Press the right arrow key and notice behavior.
EXPECTED:
5. The cursor is at the right of the Xmin field so the user may start editing the value from the right side.
ACTUAL:
5. The grid for the graph disappears and cannot be seen again while in that current editing session. It looks like this happens because the negative sign is cleared in the Xmin field, so the grid disappears because Xmin = Xmax at this point. The grid can be recovered if user leaves and comes back to Item Authoring view, with or without saving the edits, or if the user deletes/re-adds the graphing interaction. Also, Preview still displays the grid even if Authoring does not.
