### PR TITLE
Tao 840 fix number line

### DIFF
--- a/views/js/pciCreator/dev/graphNumberLineInteraction/creator/widget/states/Question.js
+++ b/views/js/pciCreator/dev/graphNumberLineInteraction/creator/widget/states/Question.js
@@ -7,7 +7,9 @@ define([
     'lodash',
     'jquery'
 ], function(stateFactory, Question, formElement, containerEditor, formTpl, _, $){
-
+    
+    'use strict';
+    
     var StateQuestion = stateFactory.extend(Question, function(){
 
         var interaction = this.widget.element,

--- a/views/js/pciCreator/dev/graphNumberLineInteraction/creator/widget/states/Question.js
+++ b/views/js/pciCreator/dev/graphNumberLineInteraction/creator/widget/states/Question.js
@@ -27,7 +27,10 @@ define([
     }, function(){
 
         containerEditor.destroy(this.widget.$container.find('.prompt'));
-        this.widget.element.data('pci').reset();
+        var pci = this.widget.element.data('pci');
+        if(pci){
+            pci.reset();
+        }
     });
 
     StateQuestion.prototype.initForm = function(){

--- a/views/js/pciCreator/dev/graphZoomNumberLineInteraction/creator/widget/states/Question.js
+++ b/views/js/pciCreator/dev/graphZoomNumberLineInteraction/creator/widget/states/Question.js
@@ -7,7 +7,9 @@ define([
     'lodash',
     'jquery'
 ], function(stateFactory, Question, formElement, containerEditor, formTpl, _, $){
-
+    
+    'use strict';
+    
     var StateQuestion = stateFactory.extend(Question, function(){
 
         var interaction = this.widget.element,
@@ -41,12 +43,6 @@ define([
             interaction = widget.element,
             $form = widget.$form,
             response = interaction.getResponseDeclaration();
-
-        var intervalSet = interaction.prop('intervals');
-        intervalSet = intervalSet ? intervalSet.split(',') : [];
-        _.each(intervalSet, function(type){
-            intervals[type].checked = true;
-        });
 
         //render the form using the form template
         $form.html(formTpl({

--- a/views/js/pciCreator/dev/graphZoomNumberLineInteraction/creator/widget/states/Question.js
+++ b/views/js/pciCreator/dev/graphZoomNumberLineInteraction/creator/widget/states/Question.js
@@ -27,7 +27,10 @@ define([
     }, function(){
 
         containerEditor.destroy(this.widget.$container.find('.prompt'));
-        this.widget.element.data('pci').reset();
+        var pci = this.widget.element.data('pci');
+        if(pci){
+            pci.reset();
+        }
     });
 
     StateQuestion.prototype.initForm = function(){


### PR DESCRIPTION
The issue reported  there https://oat-sa.atlassian.net/browse/TAO-840 is due to the race condition when dynamically loading the sources for a PCI. In this case, the creator code executes before the PCI even had any time to load.
This does not address the root of the issue but provide a practical fix to the current issue.
To fix the root, we may need to rework the PCI loading paradigm.
