### PR TITLE
increase the specificity of pci css rules

### DIFF
--- a/views/js/pciCreator/dev/graphNumberLineInteraction/runtime/css/graphNumberLineInteraction.css
+++ b/views/js/pciCreator/dev/graphNumberLineInteraction/runtime/css/graphNumberLineInteraction.css
@@ -1,6 +1,6 @@
 /*add some style, need to scope (using the typeIdentifier as class prefix) every style declaration to prevent collision */
 
-.graphNumberLineInteraction {
+html body div.qti-item .graphNumberLineInteraction {
     width:100%;
     padding:30px 30px 50px;
     margin:20px 0;
@@ -8,31 +8,27 @@
     border : 6px solid #f5f3f2;
 }
 
-.graphNumberLineInteraction .shape-controls .clearfix {
+html body div.qti-item .graphNumberLineInteraction .shape-controls .clearfix {
     overflow: auto;
 }
 
-.graphNumberLineInteraction .prompt {margin-bottom:20px;}
+html body div.qti-item .graphNumberLineInteraction .prompt {margin-bottom:20px;}
 
-.graphNumberLineInteraction .shape-controls .intervals-available {float:left; position : relative; border : 6px solid #f5f3f2; padding:4px; margin-right : 10px; margin-bottom:10px;}
-.graphNumberLineInteraction .shape-controls .intervals-available .intervals-overlay {position:absolute; width:100%; height : 100%; top:0; left:0; background: #ddd; opacity : 0.6; display:none;}
-.graphNumberLineInteraction .shape-controls .intervals-available .interval-available {display:none;}
-.graphNumberLineInteraction .shape-controls .intervals-available .interval-available.activated {display:inline-block;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-available {float:left; position : relative; border : 6px solid #f5f3f2; padding:4px; margin-right : 10px; margin-bottom:10px;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-available .intervals-overlay {position:absolute; width:100%; height : 100%; top:0; left:0; background: #ddd; opacity : 0.6; display:none;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-available .interval-available {display:none;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-available .interval-available.activated {display:inline-block;}
 
-.graphNumberLineInteraction .shape-controls .intervals-selected {float:left;}
-.graphNumberLineInteraction .shape-controls .intervals-selected .interval {float:left; position : relative; width:92px; border : 6px solid #f5f3f2; padding:4px; margin-right:10px;}
-.graphNumberLineInteraction .shape-controls .intervals-selected .interval .deleter {cursor: pointer; }
-.graphNumberLineInteraction .shape-controls .intervals-selected .interval .deleter:before {font-size:1.25rem; margin-right: 3px;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-selected {float:left;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-selected .interval {float:left; position : relative; width:92px; border : 6px solid #f5f3f2; padding:4px; margin-right:10px;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-selected .interval .deleter {cursor: pointer; }
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-selected .interval .deleter:before {font-size:1.25rem; margin-right: 3px;}
 
-.graphNumberLineInteraction .shape-controls .intervals-selected .interval .btn {margin-bottom:10px;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-selected .interval .btn {margin-bottom:10px;}
 
-.graphNumberLineInteraction .shape-controls button {padding: 0 6px 8px; height:36px; width:72px; margin-right:2px;}
-.graphNumberLineInteraction .shape-controls button img {height:20px;width:50px;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls button {padding: 0 6px 8px; height:36px; width:72px; margin-right:2px;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls button img {height:20px;width:50px;}
 
-.graphNumberLineInteraction .shape-controls .intervals-template {display:none;}
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-template {display:none;}
 
-.graphNumberLineInteraction .shape-controls .intervals-row {margin-bottom: 2px;}
-
-/*alternative deleter*/
-/*.graphNumberLineInteraction .shape-controls .intervals-selected .interval .interval-delete {cursor: pointer; position:absolute; top:0; right:0; font-size:2rem;}
-.graphNumberLineInteraction .shape-controls .intervals-selected .interval .deleter {display:none;}*/
+html body div.qti-item .graphNumberLineInteraction .shape-controls .intervals-row {margin-bottom: 2px;}


### PR DESCRIPTION
The issue was caused by the css of the themes that mistakenly overwrite the rule that is supposed to ensure proper display for the icons.
